### PR TITLE
Unsplash API proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ bpe_simple_vocab_16e6.txt.gz
 unsplash-dataset/**/*.jpg
 unsplash-dataset/**/*.csv
 unsplash-dataset/**/*.npy
+
+# Serverless
+unsplash-proxy/.serverless

--- a/setup-clip.ipynb
+++ b/setup-clip.ipynb
@@ -72,7 +72,7 @@
    ],
    "source": [
     "# Clone the CLIP repository\n",
-    "!git clone git@github.com:openai/CLIP.git\n",
+    "!git clone https://github.com/openai/CLIP.git\n",
     "\n",
     "# Move the CLIP source files and the vocabulary in the root directory. \n",
     "# Unfortunately, the CLIP code is not organized as a module, so it cannot be imported easily\n",

--- a/unsplash-proxy/handler.py
+++ b/unsplash-proxy/handler.py
@@ -1,0 +1,35 @@
+import boto3
+from urllib.request import urlopen
+
+
+def get_photo(event, context):
+    """ Function that proxies the call to the Unsplash API to retrieve the photo meta data """
+
+    # Get the photo ID from the parameters
+    photo_id = event["pathParameters"]["id"]
+
+    # Get the Unsplash Access Key from the Parameter Store
+    client = boto3.client("ssm")
+    access_key = client.get_parameter(Name="UNSPLAH_API_ACCESS_KEY")["Parameter"][
+        "Value"
+    ]
+
+    # Call the Unsplash API to get the photo metadata
+    photo_data = (
+        urlopen(f"https://api.unsplash.com/photos/{photo_id}?client_id={access_key}")
+        .read()
+        .decode("utf-8")
+    )
+
+    # Create the repsonse and return
+    headers = {
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+    }
+
+    return {
+        "statusCode": 200,
+        "headers": headers,
+        "body": photo_data,
+    }

--- a/unsplash-proxy/serverless.yml
+++ b/unsplash-proxy/serverless.yml
@@ -1,0 +1,24 @@
+service: unsplash-proxy
+app: unsplash-proxy
+org: haltakov
+
+frameworkVersion: "2"
+
+provider:
+    name: aws
+    runtime: python3.8
+    iamRoleStatements:
+        - Effect: Allow
+          Action:
+              - ssm:GetParameter
+          Resource: "arn:aws:ssm:us-east-1:018469183656:parameter/UNSPLAH_API_ACCESS_KEY"
+
+functions:
+    get_photo:
+        handler: handler.get_photo
+        memorySize: 256
+        events:
+            - http:
+                  path: get_photo/{id}
+                  method: get
+                  cors: true


### PR DESCRIPTION
This PR implements a simple proxy for the Unsplash API. The goal is to be able to get the metadata of a photos using the Unsplash API without exposing the application access key.